### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,16 +15,15 @@
     ],
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "4.1.*"
+        "illuminate/support": "~4.1"
     },
     "require-dev": {
-        "phpspec/phpspec": "2.0.*@dev",
-        "mockery/mockery": "0.9.*"
+        "phpspec/phpspec": "~2.0",
+        "mockery/mockery": "~0.9"
     },
     "autoload": {
         "psr-0": {
             "Laracasts\\Presenter": "src/"
         }
-    },
-    "minimum-stability": "stable"
+    }
 }


### PR DESCRIPTION
I've updated the `lluminate/support` to allow use in future version of laravel too. I've updated `phpspec/phpspec` to allow future non-braking versions and removed the dev flag since 2.0 is released now. I have loosed the mockery dependency because any more 0.x releases will not be breaking as the next planned version is 1.0. Finally, I have removed `minimum-stability` because it already defaults to stable.
