### PR TITLE
Make our PresentableTrait a bit smarter

### DIFF
--- a/src/Laracasts/Presenter/PresentableTrait.php
+++ b/src/Laracasts/Presenter/PresentableTrait.php
@@ -19,9 +19,14 @@ trait PresentableTrait {
 	 */
 	public function present()
 	{
-		if ( ! $this->presenter or ! class_exists($this->presenter))
+        	if ( ! $this->presenter ) 
+        	{
+            		$this->presenter = get_class($this).'Presenter';
+		}
+
+		if ( ! class_exists($this->presenter) )
 		{
-			throw new PresenterException('Please set the $presenter property to your presenter path.');
+			throw new PresenterException('Presenter Not Found : '.$this->presenter);
 		}
 
 		if ( ! $this->presenterInstance)


### PR DESCRIPTION
Now we can forget to set the Presenter Name. It will add Presenter at the end of the class name to automatically find our Presenter. Of course if you specify the Presenter name as you already do or want to follow a different naming convention it will respect that so this change is backwards compatible. Will simply save me from entering the Presenter name where I include this trait!  Hurray 1 less line of code in all my Eloquent models :)

P.S. congrats on your work, it really makes using laravel a lot more fun!
