### PR TITLE
Added ability to call methods on entity via presenter

### DIFF
--- a/spec/Laracasts/Presenter/PresenterSpec.php
+++ b/spec/Laracasts/Presenter/PresenterSpec.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace spec\Laracasts\Presenter;
+
+use PhpSpec\ObjectBehavior;
+use Prophecy\Argument;
+
+use Laracasts\Presenter\Presenter;
+
+class PresenterSpec extends ObjectBehavior
+{
+    function let()
+    {
+        $this->beAnInstanceOf('spec\Laracasts\Presenter\ExamplePresenter');
+        $this->beConstructedWith(new ExampleEntity);
+    }
+
+    function it_retrieves_properties_of_its_entity()
+    {
+        $foo = $this->foo->shouldEqual('bar');;
+    }
+
+    function it_calls_methods_of_its_entity_if_the_method_is_not_defined()
+    {
+        $this->baz()->shouldReturn(['foo', 'bar']);
+    }
+
+    function it_calls_methods_of_its_entity_if_the_method_is_not_defined_and_passes_the_arguments()
+    {
+        $this->multiply(1, 2, 3)->shouldReturn(6);
+    }
+}
+
+class ExampleEntity {
+    public $foo = 'bar';
+
+    public function baz()
+    {
+        return ['foo', 'bar'];
+    }
+
+    public function multiply($x, $y, $z)
+    {
+        return $x * $y * $z;
+    }
+}
+
+class ExamplePresenter extends Presenter {
+
+}

--- a/src/Laracasts/Presenter/Presenter.php
+++ b/src/Laracasts/Presenter/Presenter.php
@@ -31,4 +31,21 @@ abstract class Presenter {
 		return $this->entity->{$property};
 	}
 
-} 
+	/**
+	 * Allow for method-style retrieval
+	 *
+	 * @param $method
+	 * @param $arguments
+	 * @return mixed
+	 */
+	public function __call($method, $arguments)
+	{
+		if (method_exists($this->entity, $method))
+		{
+			return call_user_func_array([$this->entity, $method], $arguments);
+		}
+
+		throw new \Exception("Method not found on presenter or its entity.");
+	}
+
+}


### PR DESCRIPTION
Similar to #13, however it is using the `__call` method.
I also added a Presenter spec, though I'm not really happy with how it looks. I couldn't figure out how to mock magic methods with phpspec so I had to create an example entity class.

(The idea from this pr came from [this topic on Laracasts](https://laracasts.com/discuss/channels/general-discussion/access-method-in-user-model-inside-the-presenter).)
