### PR TITLE
Correct isset behaviour

### DIFF
--- a/src/Laracasts/Presenter/Presenter.php
+++ b/src/Laracasts/Presenter/Presenter.php
@@ -31,4 +31,16 @@ abstract class Presenter {
 		return $this->entity->{$property};
 	}
 
+
+	/**
+	 * Provide compatibility for the 'or' syntax in Blade templates
+	 *
+	 * @param $property
+	 * @return boolean
+	 */
+	public function __isset($property)
+	{
+		return method_exists($this, $property);
+	}
+
 } 


### PR DESCRIPTION
In order to be able to use ternary / Laravel Blade `or` syntax, provide an `__isset` magic method.