### PR TITLE
Update README to require series 2.x releases.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Pull this package in through Composer.
 ```js
 {
     "require": {
-        "laracasts/presenter": "0.1.*"
+        "laracasts/presenter": "0.2.*"
     }
 }
 ```


### PR DESCRIPTION
For Laravel 5. 

Thank you Jeffrey for all your efforts. 
-Bob